### PR TITLE
Adding support for DisplayModes for all .Net based templates and functions

### DIFF
--- a/Composite/AspNet/DisplayModeFacade.cs
+++ b/Composite/AspNet/DisplayModeFacade.cs
@@ -1,0 +1,39 @@
+﻿using System.Web;
+using System.Web.WebPages;
+
+namespace Composite.AspNet
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class DisplayModeFacade
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public static void Initialize()
+        {
+            DisplayModeProvider.Instance.Modes.Insert(0, new LegacyC1DisplayMode("mobile")
+            {
+                ContextCondition = ctx => ctx.GetOverriddenBrowser().IsMobileDevice
+            });
+
+            DisplayModeProvider.Instance.Modes.Insert(0, new DefaultDisplayMode("print")
+            {
+                ContextCondition = PrintCondition
+            });
+
+            DisplayModeProvider.Instance.Modes.Insert(0, new LegacyC1DisplayMode("print")
+            {
+                ContextCondition = PrintCondition
+            });
+        }
+
+        private static bool PrintCondition(HttpContextBase ctx)
+        {
+            var qs = ctx.Request.QueryString;
+
+            return qs.AllKeys.Length > 0 && qs.Keys[0] == null && qs[0] == "print";
+        }
+    }
+}

--- a/Composite/AspNet/DisplayModeFacade.cs
+++ b/Composite/AspNet/DisplayModeFacade.cs
@@ -3,14 +3,8 @@ using System.Web.WebPages;
 
 namespace Composite.AspNet
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    public static class DisplayModeFacade
+    internal static class DisplayModeFacade
     {
-        /// <summary>
-        /// 
-        /// </summary>
         public static void Initialize()
         {
             DisplayModeProvider.Instance.Modes.Insert(0, new LegacyC1DisplayMode("mobile")

--- a/Composite/AspNet/DisplayModeFacade.cs
+++ b/Composite/AspNet/DisplayModeFacade.cs
@@ -1,5 +1,4 @@
-﻿using System.Web;
-using System.Web.WebPages;
+﻿using System.Web.WebPages;
 
 namespace Composite.AspNet
 {
@@ -11,23 +10,6 @@ namespace Composite.AspNet
             {
                 ContextCondition = ctx => ctx.GetOverriddenBrowser().IsMobileDevice
             });
-
-            DisplayModeProvider.Instance.Modes.Insert(0, new DefaultDisplayMode("print")
-            {
-                ContextCondition = PrintCondition
-            });
-
-            DisplayModeProvider.Instance.Modes.Insert(0, new LegacyC1DisplayMode("print")
-            {
-                ContextCondition = PrintCondition
-            });
-        }
-
-        private static bool PrintCondition(HttpContextBase ctx)
-        {
-            var qs = ctx.Request.QueryString;
-
-            return qs.AllKeys.Length > 0 && qs.Keys[0] == null && qs[0] == "print";
         }
     }
 }

--- a/Composite/AspNet/LegacyC1DisplayMode.cs
+++ b/Composite/AspNet/LegacyC1DisplayMode.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using System.Web.WebPages;
+
+namespace Composite.AspNet
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class LegacyC1DisplayMode : DefaultDisplayMode
+    {
+        public override string DisplayModeId
+        {
+            get { return base.DisplayModeId + "_c1_legacy"; }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="suffix"></param>
+        public LegacyC1DisplayMode(string suffix) : base(suffix) { }
+
+        protected override string TransformPath(string virtualPath, string suffix)
+        {
+            if (String.IsNullOrEmpty(suffix))
+            {
+                return virtualPath;
+            }
+
+            var directory = Path.GetDirectoryName(virtualPath);
+            var extension = Path.GetExtension(virtualPath);
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(virtualPath);
+
+            return Path.Combine(directory, fileNameWithoutExtension + "_" + suffix + extension);
+        }
+    }
+}

--- a/Composite/AspNet/LegacyC1DisplayMode.cs
+++ b/Composite/AspNet/LegacyC1DisplayMode.cs
@@ -4,20 +4,13 @@ using System.Web.WebPages;
 
 namespace Composite.AspNet
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    public class LegacyC1DisplayMode : DefaultDisplayMode
+    internal class LegacyC1DisplayMode : DefaultDisplayMode
     {
         public override string DisplayModeId
         {
             get { return base.DisplayModeId + "_c1_legacy"; }
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="suffix"></param>
         public LegacyC1DisplayMode(string suffix) : base(suffix) { }
 
         protected override string TransformPath(string virtualPath, string suffix)

--- a/Composite/AspNet/Razor/RazorHelper.cs
+++ b/Composite/AspNet/Razor/RazorHelper.cs
@@ -6,6 +6,7 @@ using System.Web;
 using System.Web.WebPages;
 using System.Xml;
 using System.Xml.Linq;
+using Composite.Core.Application;
 //using Composite.Core.Extensions;
 //using Composite.Core.IO;
 using Composite.Core.Types;
@@ -38,6 +39,15 @@ namespace Composite.AspNet.Razor
             WebPageBase webPage = null;
             try
             {
+                var currentContext = HttpContext.Current;
+                if (currentContext != null)
+                {
+                    var directory = Path.GetDirectoryName(virtualPath);
+                    var function = Path.GetFileNameWithoutExtension(virtualPath);
+
+                    virtualPath = SpecialModesFileResolver.ResolveFileInInDirectory(directory, function, ".cshtml", new HttpContextWrapper(currentContext));
+                }
+
                 webPage = WebPageBase.CreateInstanceFromVirtualPath(virtualPath);
 
                 return ExecuteRazorPage(webPage, setParameters, resultType, functionContextContainer);

--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -152,6 +152,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AspNet\CompositeC1SiteMapProvider.cs" />
+    <Compile Include="AspNet\DisplayModeFacade.cs" />
+    <Compile Include="AspNet\LegacyC1DisplayMode.cs" />
     <Compile Include="AspNet\Razor\RazorFunction.cs" />
     <Compile Include="AspNet\Razor\RazorHelper.cs" />
     <Compile Include="AspNet\Razor\RazorPageTemplate.cs" />
@@ -189,6 +191,7 @@
     <Compile Include="C1Console\Trees\SortDirection.cs" />
     <Compile Include="Core\Application\ServiceLocator.cs" />
     <Compile Include="Core\Application\Job.cs" />
+    <Compile Include="Core\Application\SpecialModesFileResolver.cs" />
     <Compile Include="Core\Caching\FileRelatedDataCache.cs" />
     <Compile Include="Core\Extensions\StackTraceExtensionMethods.cs" />
     <Compile Include="Core\Instrumentation\LogExecutionTime.cs" />

--- a/Composite/Core/Application/SpecialModesFileResolver.cs
+++ b/Composite/Core/Application/SpecialModesFileResolver.cs
@@ -6,19 +6,10 @@ using System.Web.WebPages;
 
 namespace Composite.Core.Application
 {
-    /// <summary>
-    /// 
-    /// </summary>
+    /// <exclude />
     public static class SpecialModesFileResolver
     {
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="directory"></param>
-        /// <param name="file"></param>
-        /// <param name="extension"></param>
-        /// <param name="context"></param>
-        /// <returns></returns>
+        /// <exclude />
         public static string ResolveFileInInDirectory(string directory, string file, string extension, HttpContextBase context)
         {
             var pathProvider = HostingEnvironment.VirtualPathProvider;
@@ -36,12 +27,8 @@ namespace Composite.Core.Application
             }
 
             file = Path.Combine(directory, file + extension);
-            if (pathProvider.FileExists(file))
-            {
-                return file;
-            }
-
-            return null;
+            
+            return pathProvider.FileExists(file) ? file : null;
         }
     }
 }

--- a/Composite/Core/Application/SpecialModesFileResolver.cs
+++ b/Composite/Core/Application/SpecialModesFileResolver.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Web;
+using System.Web.Hosting;
+using System.Web.WebPages;
+
+namespace Composite.Core.Application
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class SpecialModesFileResolver
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="directory"></param>
+        /// <param name="file"></param>
+        /// <param name="extension"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static string ResolveFileInInDirectory(string directory, string file, string extension, HttpContextBase context)
+        {
+            var pathProvider = HostingEnvironment.VirtualPathProvider;
+            var modes = DisplayModeProvider.Instance.GetAvailableDisplayModesForContext(context, null);
+
+            foreach (var mode in modes)
+            {
+                var specialFile = Path.Combine(directory, String.Format("{0}{1}", file, extension));
+
+                var displayInfo = mode.GetDisplayInfo(context, specialFile, pathProvider.FileExists);
+                if (displayInfo != null)
+                {
+                    return displayInfo.FilePath;
+                }
+            }
+
+            file = Path.Combine(directory, file + extension);
+            if (pathProvider.FileExists(file))
+            {
+                return file;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Composite/Core/PageTemplates/TemplateDefinitionHelper.cs
+++ b/Composite/Core/PageTemplates/TemplateDefinitionHelper.cs
@@ -103,7 +103,7 @@ namespace Composite.Core.PageTemplates
         /// <param name="pageContentToRender">The page rendering job.</param>
         /// <param name="placeholderProperties">The placeholder properties.</param>
         /// <param name="functionContextContainer">The function context container, if not null, nested functions fill be evaluated.</param>
-        public static void BindPlaceholders(IPageTemplate template, 
+        public static void BindPlaceholders(object template,
                                      PageContentToRender pageContentToRender,
                                      IDictionary<string, PropertyInfo> placeholderProperties,
                                      FunctionContextContainer functionContextContainer)

--- a/Composite/Core/WebClient/ApplicationLevelEventHandlers.cs
+++ b/Composite/Core/WebClient/ApplicationLevelEventHandlers.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Web;
+using Composite.AspNet;
 using Composite.C1Console.Elements;
 using Composite.C1Console.Events;
 using Composite.Core.Application;
@@ -344,6 +345,7 @@ namespace Composite.Core.WebClient
             TempDirectoryFacade.OnApplicationStart();
 
             HostnameBindingsFacade.Initialize();
+            DisplayModeFacade.Initialize();
 
             ApplicationStartupFacade.FireSystemInitialized();
 

--- a/Composite/Core/WebClient/Renderings/RenderingContext.cs
+++ b/Composite/Core/WebClient/Renderings/RenderingContext.cs
@@ -258,23 +258,35 @@ namespace Composite.Core.WebClient.Renderings
             Verify.IsNotNull(httpContext.Handler, "HttpHandler isn't defined");
 
             var aspnetPage = (System.Web.UI.Page)httpContext.Handler;
-            var qs = request.QueryString;
+            
+            OverrideDisplayMode(httpContext);
+
+            var pageRenderer = PageTemplateFacade.BuildPageRenderer(Page.TemplateId);
+            pageRenderer.AttachToPage(aspnetPage, pageRenderingJob);
+        }
+
+        private static void OverrideDisplayMode(HttpContextBase httpContext)
+        {
+            var qs = httpContext.Request.QueryString;
+            var displayMode = qs["c1displaymode"];
 
             if (qs.AllKeys.Length > 0 && qs.Keys[0] == null)
             {
-                if (qs[0] == "mobile")
+                displayMode = qs[0];
+            }
+
+            if (!String.IsNullOrEmpty(displayMode))
+            {
+                if (displayMode.Equals("mobile", StringComparison.OrdinalIgnoreCase))
                 {
                     httpContext.SetOverriddenBrowser(BrowserOverride.Mobile);
                 }
 
-                if (qs[0] == "desktop")
+                if (displayMode.Equals("desktop", StringComparison.OrdinalIgnoreCase))
                 {
                     httpContext.SetOverriddenBrowser(BrowserOverride.Desktop);
                 }
             }
-            
-            var pageRenderer = PageTemplateFacade.BuildPageRenderer(Page.TemplateId);
-            pageRenderer.AttachToPage(aspnetPage, pageRenderingJob);
         }
 
         private void ValidateViewUnpublishedRequest(HttpContextBase httpContext)

--- a/Composite/Plugins/Functions/FunctionProviders/UserControlFunctionProvider/UserControlBasedFunction.cs
+++ b/Composite/Plugins/Functions/FunctionProviders/UserControlFunctionProvider/UserControlBasedFunction.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Web;
 using System.Web.UI;
 using Composite.AspNet;
+using Composite.Core.Application;
 using Composite.Core.IO;
 using Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvider;
 
@@ -51,6 +53,10 @@ namespace Composite.Plugins.Functions.FunctionProviders.UserControlFunctionProvi
 
             Page currentPage = httpContext.Handler as Page;
             Verify.IsNotNull(currentPage, "The Current HttpContext Handler must be a " + typeof (Page).FullName);
+
+            var directory = Path.GetDirectoryName(VirtualPath);
+            var function = Path.GetFileNameWithoutExtension(VirtualPath);
+            var virtualPath = SpecialModesFileResolver.ResolveFileInInDirectory(directory, function, ".ascx", new HttpContextWrapper(httpContext));
 
             var userControl = currentPage.LoadControl(VirtualPath);
 

--- a/Composite/Plugins/PageTemplates/MasterPages/MasterPagePageRenderer.cs
+++ b/Composite/Plugins/PageTemplates/MasterPages/MasterPagePageRenderer.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.IO;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using System.Xml.Linq;
 using System.Linq;
+using System.Web;
 using Composite.C1Console.Security;
+using Composite.Core.Application;
 using Composite.Core.Collections.Generic;
 using Composite.Core.Extensions;
 using Composite.Core.PageTemplates;
@@ -14,7 +17,7 @@ using Composite.Data.Types;
 
 namespace Composite.Plugins.PageTemplates.MasterPages
 {
-    internal class MasterPagePageRenderer: IPageRenderer
+    internal class MasterPagePageRenderer : IPageRenderer
     {
         private static readonly string PageRenderingJob_Key = "MasterPages.PageRenderingJob";
 
@@ -41,10 +44,10 @@ namespace Composite.Plugins.PageTemplates.MasterPages
             Guid templateId = contentToRender.Page.TemplateId;
             var rendering = _renderingInfo[templateId];
 
-            if(rendering == null)
+            if (rendering == null)
             {
                 Exception loadingException = _loadingExceptions[templateId];
-                if(loadingException != null)
+                if (loadingException != null)
                 {
                     throw loadingException;
                 }
@@ -52,10 +55,14 @@ namespace Composite.Plugins.PageTemplates.MasterPages
                 Verify.ThrowInvalidOperationException("Failed to get master page by template ID '{0}'. Check for compilation errors".FormatWith(templateId));
             }
 
-            aspnetPage.MasterPageFile = rendering.VirtualPath;
+            var dir = Path.GetDirectoryName(rendering.VirtualPath);
+            var template = Path.GetFileNameWithoutExtension(rendering.VirtualPath);
+            var file = SpecialModesFileResolver.ResolveFileInInDirectory(dir, template, ".master", new HttpContextWrapper(HttpContext.Current));
+
+            aspnetPage.MasterPageFile = file;
             aspnetPage.PreRender += (e, args) => PageOnPreRender(aspnetPage, contentToRender.Page);
 
-            var master = aspnetPage.Master as MasterPagePageTemplate;
+            var master = aspnetPage.Master;
             TemplateDefinitionHelper.BindPlaceholders(master, contentToRender, rendering.PlaceholderProperties, null);
         }
 
@@ -76,7 +83,7 @@ namespace Composite.Plugins.PageTemplates.MasterPages
                 {
                     string xml = string.Join(string.Empty, xhtmlDocument.Head.Nodes().Select(node => node.ToString()));
 
-                    aspnetPage.Header.Controls.Add(new Literal {Text = xml});
+                    aspnetPage.Header.Controls.Add(new Literal { Text = xml });
                 }
             }
         }


### PR DESCRIPTION
DisplayModes is a native part of WebPages and MVC so its only natural that Composite C1 also supports it for its Functions and Templates.

This pullrequest adds supports for the default file-resolving exposed by DisplayModeProvider.GetAvailableDisplayModesForContext (https://msdn.microsoft.com/en-us/library/system.web.webpages.displaymodeprovider.getavailabledisplaymodesforcontext(v=vs.111).aspx) to dynamically choose a different file at execution time based on the given HttpRequest.

Existing Functions and Templates works exactly the same way, but its now possible to add a .mobile.cshtml or .tablet.ascx next to the existing file, and this will then be used to service a given request, instead of the normal one.

Read more about DisplayModes here

 - https://www.simple-talk.com/dotnet/asp.net/multiple-views-and-displaymode-providers-in-asp.net-mvc-4/
 - http://www.codeproject.com/Tips/704007/Desktop-and-Mobile-Browser-View-in-MVC

The code in this Pull Request has been part of the Community Build for about 2 years so its well tested and used in various of live production sites.