### PR TITLE
GenericSortable

### DIFF
--- a/Composite.Workflows/Plugins/Elements/ElementProviders/GeneratedDataTypesElementProvider/AddNewInterfaceTypeWorkflow.cs
+++ b/Composite.Workflows/Plugins/Elements/ElementProviders/GeneratedDataTypesElementProvider/AddNewInterfaceTypeWorkflow.cs
@@ -37,6 +37,7 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
             public const string InternalUrlPrefix = "InternalUrlPrefix";
             public const string HasCaching = "HasCaching";
             public const string HasPublishing = "HasPublishing";
+            public const string HasSorting = "HasSorting";
             public const string HasLocalization = "HasLocalization";
             public const string KeyFieldReadOnly = "KeyFieldReadOnly";
         }
@@ -62,6 +63,7 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
                 {BindingNames.DataFieldDescriptors, dataFieldDescriptors},
                 {BindingNames.HasCaching, false},
                 {BindingNames.HasPublishing, false},
+                {BindingNames.HasSorting, false},
                 {BindingNames.HasLocalization, false},
                 {BindingNames.KeyFieldName, dataFieldDescriptors.First().Name},
                 {BindingNames.LabelFieldName, ""},
@@ -98,6 +100,7 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
                 string typeTitle = this.GetBinding<string>(BindingNames.NewTypeTitle);
                 bool hasCaching = this.GetBinding<bool>(BindingNames.HasCaching);
                 bool hasPublishing = this.GetBinding<bool>(BindingNames.HasPublishing);
+                bool hasSorting = this.GetBinding<bool>(BindingNames.HasSorting);
                 bool hasLocalization = this.GetBinding<bool>(BindingNames.HasLocalization);
                 string keyFieldName = this.GetBinding<string>(BindingNames.KeyFieldName);
                 string labelFieldName = this.GetBinding<string>(BindingNames.LabelFieldName);
@@ -156,7 +159,7 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
                             Texts.AddNewInterfaceTypeStep1_ErrorTitle,
                             "It's not possible to change localization through the current tab"
                         );
-                        return;             
+                        return;
                     }
                 }
 
@@ -165,8 +168,9 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
                 {
                     helper.SetCachable(hasCaching);
                     helper.SetPublishControlled(hasPublishing);
+                    helper.SetSortable(hasSorting);
                     helper.SetLocalizedControlled(hasLocalization);
-                }   
+                }
 
                 helper.SetNewTypeFullName(typeName, typeNamespace);
                 helper.SetNewTypeTitle(typeTitle);
@@ -203,8 +207,8 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
                 string serializedTypeName = TypeManager.SerializeType(helper.InterfaceType);
 
                 EntityToken entityToken = new GeneratedDataTypesElementProviderTypeEntityToken(
-                    serializedTypeName, 
-                    this.EntityToken.Source, 
+                    serializedTypeName,
+                    this.EntityToken.Source,
                     IsPageDataFolder ? GeneratedDataTypesElementProviderRootEntityToken.PageDataFolderTypeFolderId
                                      : GeneratedDataTypesElementProviderRootEntityToken.GlobalDataTypeFolderId
                 );
@@ -217,10 +221,10 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
                 {
                     SetSaveStatus(true, entityToken);
                 }
-                
+
 
                 if (!this.BindingExist(BindingNames.InterfaceType))
-                {                    
+                {
                     this.AcquireLock(entityToken);
                 }
 

--- a/Composite.Workflows/Plugins/Elements/ElementProviders/GeneratedDataTypesElementProvider/EditInterfaceTypeWorkflow.cs
+++ b/Composite.Workflows/Plugins/Elements/ElementProviders/GeneratedDataTypesElementProvider/EditInterfaceTypeWorkflow.cs
@@ -43,6 +43,7 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
             public const string InternalUrlPrefix = "InternalUrlPrefix";
             public const string HasCaching = "HasCaching";
             public const string HasPublishing = "HasPublishing";
+            public const string HasSorting = "HasSorting";
 
             public const string OldTypeName = "OldTypeName";
             public const string OldTypeNamespace = "OldTypeNamespace";
@@ -83,6 +84,7 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
                 {BindingNames.InternalUrlPrefix, dataTypeDescriptor.InternalUrlPrefix},
                 {BindingNames.HasCaching, helper.IsCachable},
                 {BindingNames.HasPublishing, helper.IsPublishControlled},
+                {BindingNames.HasSorting, helper.IsSortable},
                 {BindingNames.DataFieldDescriptors, fieldDescriptors},
                 {BindingNames.OldTypeName, dataTypeDescriptor.Name},
                 {BindingNames.OldTypeNamespace, dataTypeDescriptor.Namespace}
@@ -115,6 +117,7 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
                 string typeTitle = this.GetBinding<string>(BindingNames.TypeTitle);
                 bool hasCaching = this.GetBinding<bool>(BindingNames.HasCaching);
                 bool hasPublishing = this.GetBinding<bool>(BindingNames.HasPublishing);
+                bool hasSorting = this.GetBinding<bool>(BindingNames.HasSorting);
                 string keyFieldName = this.GetBinding<string>(BindingNames.KeyFieldName);
                 string labelFieldName = this.GetBinding<string>(BindingNames.LabelFieldName);
                 string internalUrlPrefix = this.GetBinding<string>(BindingNames.InternalUrlPrefix);
@@ -156,13 +159,14 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
                 helper.SetNewTypeFullName(typeName, typeNamespace);
                 helper.SetNewTypeTitle(typeTitle);
                 helper.SetNewInternalUrlPrefix(internalUrlPrefix);
-                
+
                 helper.SetNewFieldDescriptors(dataFieldDescriptors, keyFieldName, labelFieldName);
 
                 if (helper.IsEditProcessControlledAllowed)
                 {
                     helper.SetCachable(hasCaching);
                     helper.SetPublishControlled(hasPublishing);
+                    helper.SetSortable(hasSorting);
                     helper.SetLocalizedControlled(hasLocalization);
                 }
 
@@ -196,7 +200,7 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
 
                 SetSaveStatus(true);
 
-                var rootEntityToken = new GeneratedDataTypesElementProviderRootEntityToken(this.EntityToken.Source, 
+                var rootEntityToken = new GeneratedDataTypesElementProviderRootEntityToken(this.EntityToken.Source,
                     IsPageFolder ? GeneratedDataTypesElementProviderRootEntityToken.PageDataFolderTypeFolderId
                                  : GeneratedDataTypesElementProviderRootEntityToken.GlobalDataTypeFolderId);
 
@@ -206,7 +210,7 @@ namespace Composite.Plugins.Elements.ElementProviders.GeneratedDataTypesElementP
                 IFile markupFile = DynamicTypesAlternateFormFacade.GetAlternateFormMarkupFile(typeNamespace, typeName);
                 if (markupFile != null)
                 {
-                    ShowMessage(DialogType.Message, 
+                    ShowMessage(DialogType.Message,
                         Texts.FormMarkupInfo_Dialog_Label,
                         Texts.FormMarkupInfo_Message(Texts.EditFormMarkup, markupFile.GetRelativeFilePath()));
                 }

--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Data\PageRenderingHistory.cs" />
     <Compile Include="Data\RouteDateSegmentAttribute.cs" />
     <Compile Include="Data\RouteSegmentAttribute.cs" />
+    <Compile Include="Data\Types\IGenericSortable.cs" />
     <Compile Include="Functions\AttributeBasedRoutedDataUrlMapper.cs" />
     <Compile Include="Functions\IRoutedDataUrlMapper.cs" />
     <Compile Include="Functions\PathInfoRoutedDataUrlMapper.cs" />

--- a/Composite/Core/ResourceSystem/LocalizationFiles.cs
+++ b/Composite/Core/ResourceSystem/LocalizationFiles.cs
@@ -2655,6 +2655,12 @@ namespace Composite.Core.ResourceSystem
  public static string UnpublishDate_Label { get { return T("UnpublishDate.Label"); } } 
  /// <summary>&quot;Specify at which date and time you want the data to be unpublished automatically.&quot;</summary> 
  public static string UnpublishDate_Help { get { return T("UnpublishDate.Help"); } } 
+ /// <summary>&quot;Sorting settings&quot;</summary> 
+ public static string LocalOrdering_FieldGroupLabel { get { return T("LocalOrdering.FieldGroupLabel"); } } 
+ /// <summary>&quot;Local ordering&quot;</summary> 
+ public static string LocalOrdering_Label { get { return T("LocalOrdering.Label"); } } 
+ /// <summary>&quot;Specify the ordering of the element related to other data items on the same level. Lowest is first.&quot;</summary> 
+ public static string LocalOrdering_Help { get { return T("LocalOrdering.Help"); } } 
  /// <summary>&quot;New Datatype&quot;</summary> 
  public static string AddNewInterfaceTypeStep1_DocumentTitle { get { return T("AddNewInterfaceTypeStep1.DocumentTitle"); } } 
  /// <summary>&quot;New Page Metatype&quot;</summary> 
@@ -2705,6 +2711,8 @@ namespace Composite.Core.ResourceSystem
  public static string EditorCommon_HasPublishing { get { return T("EditorCommon.HasPublishing"); } } 
  /// <summary>&quot;Is localizable data&quot;</summary> 
  public static string EditorCommon_HasLocalization { get { return T("EditorCommon.HasLocalization"); } } 
+ /// <summary>&quot;Is sortable&quot;</summary> 
+ public static string EditorCommon_HasSorting { get { return T("EditorCommon.HasSorting"); } } 
  /// <summary>&quot;Delete Data?&quot;</summary> 
  public static string DeleteGeneratedDataStep1_LabelFieldGroup { get { return T("DeleteGeneratedDataStep1.LabelFieldGroup"); } } 
  /// <summary>&quot;Delete data?&quot;</summary> 

--- a/Composite/Data/GeneratedTypes/GeneratedTypesHelper.cs
+++ b/Composite/Data/GeneratedTypes/GeneratedTypesHelper.cs
@@ -17,7 +17,7 @@ using Texts = Composite.Core.ResourceSystem.LocalizationFiles.Composite_Generate
 
 namespace Composite.Data.GeneratedTypes
 {
-    /// <summary>    
+    /// <summary>
     /// </summary>
     /// <exclude />
     [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
@@ -49,6 +49,7 @@ namespace Composite.Data.GeneratedTypes
         private string _newTypeNamespace;
         private string _newTypeTitle;
         private bool _cachable;
+        private bool _sortable;
         private bool _publishControlled;
         private bool _localizedControlled;
 
@@ -69,7 +70,7 @@ namespace Composite.Data.GeneratedTypes
         private static readonly string CompositionDescriptionFieldName = "FieldName";
 
         //private KeyFieldType _keyFieldType = KeyFieldType.Guid;
-        
+
 
         /// <exclude />
         public GeneratedTypesHelper()
@@ -181,7 +182,16 @@ namespace Composite.Data.GeneratedTypes
             }
         }
 
+        /// <exclude />
+        public bool IsSortable
+        {
+            get
+            {
+                Verify.IsNotNull(_oldDataTypeDescriptor, "No old data type specified");
 
+                return _oldDataTypeDescriptor.SuperInterfaces.Contains(typeof(IGenericSortable));
+            }
+        }
 
         /// <exclude />
         public bool IsLocalizedControlled
@@ -444,7 +454,11 @@ namespace Composite.Data.GeneratedTypes
             _cachable = cachable;
         }
 
-
+        /// <exclude />
+        public void SetSortable(bool sortable)
+        {
+            _sortable = sortable;
+        }
 
         /// <exclude />
         public void SetPublishControlled(bool isPublishControlled)
@@ -453,8 +467,6 @@ namespace Composite.Data.GeneratedTypes
 
             _publishControlled = isPublishControlled;
         }
-
-
 
         /// <exclude />
         public void SetLocalizedControlled(bool isLocalizedControlled)
@@ -720,7 +732,7 @@ namespace Composite.Data.GeneratedTypes
 
             GeneratedTypesFacade.UpdateType(new UpdateDataTypeDescriptor(_oldDataTypeDescriptor, _newDataTypeDescriptor, originalTypeDataExists));
 
-            return true;   
+            return true;
         }
 
 
@@ -735,6 +747,7 @@ namespace Composite.Data.GeneratedTypes
                 _newInternalUrlPrefix,
                 _cachable,
                 _publishControlled,
+                _sortable,
                 _localizedControlled,
                 _newDataFieldDescriptors,
                 _foreignKeyDataFieldDescriptor,
@@ -752,6 +765,7 @@ namespace Composite.Data.GeneratedTypes
             string internalUrlPrefix,
             bool cachable,
             bool publishControlled,
+            bool sortable,
             bool localizedControlled,
             IEnumerable<DataFieldDescriptor> dataFieldDescriptors,
             DataFieldDescriptor foreignKeyDataFieldDescriptor,
@@ -772,6 +786,11 @@ namespace Composite.Data.GeneratedTypes
             if (publishControlled && _dataAssociationType != DataAssociationType.Composition)
             {
                 dataTypeDescriptor.AddSuperInterface(typeof(IPublishControlled));
+            }
+
+            if (sortable)
+            {
+                dataTypeDescriptor.AddSuperInterface(typeof(IGenericSortable));
             }
 
             if (localizedControlled)
@@ -882,7 +901,7 @@ namespace Composite.Data.GeneratedTypes
 
             Type[] indirectlyInheritedInterfaces =
             {
-                typeof(IPublishControlled), typeof(ILocalizedControlled), 
+                typeof(IPublishControlled), typeof(ILocalizedControlled), typeof(IGenericSortable),
                 typeof(IPageData), typeof(IPageFolderData), typeof(IPageMetaData)
             };
 
@@ -906,6 +925,10 @@ namespace Composite.Data.GeneratedTypes
                 dataTypeDescriptor.AddSuperInterface(typeof(ILocalizedControlled));
             }
 
+            if (_sortable)
+            {
+                dataTypeDescriptor.AddSuperInterface(typeof(IGenericSortable));
+            }
 
             if (_oldDataTypeDescriptor.SuperInterfaces.Contains(typeof(IPageFolderData)))
             {
@@ -926,7 +949,7 @@ namespace Composite.Data.GeneratedTypes
 
                 //dataTypeDescriptor.Fields.Add(idDataFieldDescriptor);
                 //dataTypeDescriptor.KeyPropertyNames.Add(KeyFieldName);
-                
+
             }
 
             dataTypeDescriptor.Title = _newTypeTitle;
@@ -1029,7 +1052,7 @@ namespace Composite.Data.GeneratedTypes
             if (dataFieldDescriptor.Inherited)
             {
                 Type superInterface = dataTypeDescriptor.SuperInterfaces.FirstOrDefault(type => type.GetProperty(dataFieldDescriptor.Name) != null);
-                
+
                 if(superInterface != null && superInterface.Assembly == typeof(IData).Assembly)
                 {
                     return false;

--- a/Composite/Data/Types/IGenericSortable.cs
+++ b/Composite/Data/Types/IGenericSortable.cs
@@ -1,0 +1,15 @@
+﻿namespace Composite.Data.Types
+{
+    /// <summary>
+    /// Defines the interface which enables sorting of data on the same level.
+    /// </summary>
+    public interface IGenericSortable : IData
+    {
+        /// <exclude />
+        [StoreFieldType(PhysicalStoreFieldType.Integer)]
+        [ImmutableFieldId("{87BD6871-CF25-48f2-9ED5-BF41B272551F}")]
+        [DefaultFieldIntValue(0)]
+        [TreeOrdering(999)]
+        int LocalOrdering { get; set; }
+    }
+}

--- a/Composite/Data/Types/IPageStructure.cs
+++ b/Composite/Data/Types/IPageStructure.cs
@@ -1,37 +1,25 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
+using System.ComponentModel;
 
 namespace Composite.Data.Types
 {
-    /// <summary>    
-    /// </summary>
     /// <exclude />
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [AutoUpdateble]
     [ImmutableTypeId("{797A1A98-6E5C-4a1e-B346-AE547A1F4E90}")]
     [KeyPropertyName("Id")]
     [DataScope(DataScopeIdentifier.PublicName)]
-    [CachingAttribute(CachingType.Full)]    
-	public interface IPageStructure : IData
-	{
+    [Caching(CachingType.Full)]
+    public interface IPageStructure : IGenericSortable
+    {
         /// <exclude />
         [StoreFieldType(PhysicalStoreFieldType.Guid)]
         [ImmutableFieldId("{CBB49E56-A05C-4a33-9F8B-9253C2EDB9C2}")]
         Guid Id { get; set; }
 
-
         /// <exclude />
         [StoreFieldType(PhysicalStoreFieldType.Guid)]
         [ImmutableFieldId("{57AF0FDA-BA4F-4281-ACAF-A56C28FEF2E6}")]
         Guid ParentId { get; set; }
-
-
-        /// <exclude />
-        [StoreFieldType(PhysicalStoreFieldType.Integer)]
-        [ImmutableFieldId("{87BD6871-CF25-48f2-9ED5-BF41B272551F}")]
-        int LocalOrdering { get; set; }
-	}
+    }
 }

--- a/Website/Composite/content/forms/Administrative/AddNewInterfaceTypeStep1.xml
+++ b/Website/Composite/content/forms/Administrative/AddNewInterfaceTypeStep1.xml
@@ -1,80 +1,86 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <cms:formdefinition xmlns="http://www.composite.net/ns/management/bindingforms/std.ui.controls.lib/1.0" xmlns:internal="http://www.composite.net/ns/management/bindingforms/internal.ui.controls.lib/1.0" xmlns:f="http://www.composite.net/ns/management/bindingforms/std.function.lib/1.0" xmlns:cms="http://www.composite.net/ns/management/bindingforms/1.0">
-  <cms:bindings>
-    <cms:binding name="ViewLabel" type="System.String" />
-    <cms:binding name="NewTypeName" type="System.String" />
-    <cms:binding name="NewTypeNamespace" type="System.String" />
-    <cms:binding name="NewTypeTitle" type="System.String" />
-    <cms:binding name="DataFieldDescriptors" type="System.Object" />
-    <cms:binding name="HasCaching" type="System.Boolean" />
-    <cms:binding name="HasPublishing" type="System.Boolean" />
-    <cms:binding name="HasLocalization" type="System.Boolean" />
-    <cms:binding name="KeyFieldName" type="System.String" />
-    <cms:binding name="LabelFieldName" type="System.String" optional="true" />
-    <cms:binding name="InternalUrlPrefix" type="System.String" optional="true" />
-    <cms:binding name="KeyFieldReadOnly" type="System.Boolean" />
-  </cms:bindings>
-  <cms:layout iconhandle="generated-type-add">
-    <TabPanels>
-      <TabPanels.Label>
-        <cms:read source="ViewLabel" />
-      </TabPanels.Label>
-      <PlaceHolder Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.SettingsTab}">
+	<cms:bindings>
+		<cms:binding name="ViewLabel" type="System.String" />
+		<cms:binding name="NewTypeName" type="System.String" />
+		<cms:binding name="NewTypeNamespace" type="System.String" />
+		<cms:binding name="NewTypeTitle" type="System.String" />
+		<cms:binding name="DataFieldDescriptors" type="System.Object" />
+		<cms:binding name="HasCaching" type="System.Boolean" />
+		<cms:binding name="HasPublishing" type="System.Boolean" />
+		<cms:binding name="HasSorting" type="System.Boolean" />
+		<cms:binding name="HasLocalization" type="System.Boolean" />
+		<cms:binding name="KeyFieldName" type="System.String" />
+		<cms:binding name="LabelFieldName" type="System.String" optional="true" />
+		<cms:binding name="InternalUrlPrefix" type="System.String" optional="true" />
+		<cms:binding name="KeyFieldReadOnly" type="System.Boolean" />
+	</cms:bindings>
+	<cms:layout iconhandle="generated-type-add">
+		<TabPanels>
+			<TabPanels.Label>
+				<cms:read source="ViewLabel" />
+			</TabPanels.Label>
+			<PlaceHolder Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.SettingsTab}">
 
-        <FieldGroup Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTitleGroup}">
-          <TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTitle}" Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HelpTitle}">
-            <cms:bind source="NewTypeTitle" />
-          </TextBox>
-        </FieldGroup>
+				<FieldGroup Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTitleGroup}">
+					<TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTitle}" Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HelpTitle}">
+						<cms:bind source="NewTypeTitle" />
+					</TextBox>
+				</FieldGroup>
 
 
-        <FieldGroup Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelProgrammaticNamingAndServices}">
-          <TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTypeName}"
+				<FieldGroup Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelProgrammaticNamingAndServices}">
+					<TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTypeName}"
                Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HelpTypeName}" Type="ProgrammingIdentifier">
-            <cms:bind source="NewTypeName" />
-          </TextBox>
-          
-          <TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTypeNamespace}" Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HelpTypeNamespace}" Type="ProgrammingNamespace">
-            <cms:bind source="NewTypeNamespace" />
-          </TextBox>
+						<cms:bind source="NewTypeName" />
+					</TextBox>
 
-          <TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.InternalUrlPrefixLabel}" Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.InternalUrlPrefixHelp}" Type="programmingidentifier">
-            <cms:bind source="InternalUrlPrefix" />
-          </TextBox>
-          
-          <PlaceHolder Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.ServicesLabel}">
-            <CheckBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasCaching}" ItemLabel="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasCaching}">
-              <CheckBox.Checked>
-                <cms:bind source="HasCaching" />
-              </CheckBox.Checked>
-            </CheckBox>
-            <CheckBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasPublishing}" ItemLabel="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasPublishing}">
-              <CheckBox.Checked>
-                <cms:bind source="HasPublishing" />
-              </CheckBox.Checked>
-            </CheckBox>
-            <CheckBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasLocalization}" ItemLabel="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasLocalization}">
-              <CheckBox.Checked>
-                <cms:bind source="HasLocalization" />
-              </CheckBox.Checked>
-            </CheckBox>
-          </PlaceHolder>
-        </FieldGroup>
-      </PlaceHolder>
-      <internal:TypeFieldDesigner Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelFields}">
-        <internal:TypeFieldDesigner.Fields>
-          <cms:bind source="DataFieldDescriptors" />
-        </internal:TypeFieldDesigner.Fields>
-        <internal:TypeFieldDesigner.KeyFieldName>
-          <cms:bind source="KeyFieldName" />
-        </internal:TypeFieldDesigner.KeyFieldName>
-        <internal:TypeFieldDesigner.LabelFieldName>
-          <cms:bind source="LabelFieldName" />
-        </internal:TypeFieldDesigner.LabelFieldName>
-        <internal:TypeFieldDesigner.KeyFieldReadOnly>
-          <cms:bind source="KeyFieldReadOnly" />
-        </internal:TypeFieldDesigner.KeyFieldReadOnly>
-      </internal:TypeFieldDesigner>
-    </TabPanels>
-  </cms:layout>
+					<TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTypeNamespace}" Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HelpTypeNamespace}" Type="ProgrammingNamespace">
+						<cms:bind source="NewTypeNamespace" />
+					</TextBox>
+
+					<TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.InternalUrlPrefixLabel}" Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.InternalUrlPrefixHelp}" Type="programmingidentifier">
+						<cms:bind source="InternalUrlPrefix" />
+					</TextBox>
+
+					<PlaceHolder Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.ServicesLabel}">
+						<CheckBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasCaching}" ItemLabel="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasCaching}">
+							<CheckBox.Checked>
+								<cms:bind source="HasCaching" />
+							</CheckBox.Checked>
+						</CheckBox>
+						<CheckBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasPublishing}" ItemLabel="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasPublishing}">
+							<CheckBox.Checked>
+								<cms:bind source="HasPublishing" />
+							</CheckBox.Checked>
+						</CheckBox>
+						<CheckBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasSorting}" ItemLabel="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasSorting}">
+							<CheckBox.Checked>
+								<cms:bind source="HasSorting" />
+							</CheckBox.Checked>
+						</CheckBox>
+						<CheckBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasLocalization}" ItemLabel="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasLocalization}">
+							<CheckBox.Checked>
+								<cms:bind source="HasLocalization" />
+							</CheckBox.Checked>
+						</CheckBox>
+					</PlaceHolder>
+				</FieldGroup>
+			</PlaceHolder>
+			<internal:TypeFieldDesigner Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelFields}">
+				<internal:TypeFieldDesigner.Fields>
+					<cms:bind source="DataFieldDescriptors" />
+				</internal:TypeFieldDesigner.Fields>
+				<internal:TypeFieldDesigner.KeyFieldName>
+					<cms:bind source="KeyFieldName" />
+				</internal:TypeFieldDesigner.KeyFieldName>
+				<internal:TypeFieldDesigner.LabelFieldName>
+					<cms:bind source="LabelFieldName" />
+				</internal:TypeFieldDesigner.LabelFieldName>
+				<internal:TypeFieldDesigner.KeyFieldReadOnly>
+					<cms:bind source="KeyFieldReadOnly" />
+				</internal:TypeFieldDesigner.KeyFieldReadOnly>
+			</internal:TypeFieldDesigner>
+		</TabPanels>
+	</cms:layout>
 </cms:formdefinition>

--- a/Website/Composite/content/forms/Administrative/EditInterfaceTypeStep1.xml
+++ b/Website/Composite/content/forms/Administrative/EditInterfaceTypeStep1.xml
@@ -1,69 +1,75 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <cms:formdefinition xmlns="http://www.composite.net/ns/management/bindingforms/std.ui.controls.lib/1.0" xmlns:internal="http://www.composite.net/ns/management/bindingforms/internal.ui.controls.lib/1.0" xmlns:f="http://www.composite.net/ns/management/bindingforms/std.function.lib/1.0" xmlns:cms="http://www.composite.net/ns/management/bindingforms/1.0">
-    <cms:bindings>
-        <cms:binding name="TypeName" type="System.String" />
-        <cms:binding name="TypeNamespace" type="System.String" />
-        <cms:binding name="TypeTitle" type="System.String" />
-        <cms:binding name="DataFieldDescriptors" type="System.Object" />
-        <cms:binding name="HasCaching" type="System.Boolean" />
-        <cms:binding name="HasPublishing" type="System.Boolean" />
-        <cms:binding name="KeyFieldName" type="System.String" optional="true" />
-        <cms:binding name="LabelFieldName" type="System.String" optional="true" />
-        <cms:binding name="InternalUrlPrefix" type="System.String" optional="true" />
-    </cms:bindings>
-    <cms:layout iconhandle="generated-type-edit">
-        <cms:layout.label>
-            <cms:read source="TypeName"/>
-        </cms:layout.label>
-        <TabPanels>
-            <PlaceHolder Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.SettingsTab}">
+	<cms:bindings>
+		<cms:binding name="TypeName" type="System.String" />
+		<cms:binding name="TypeNamespace" type="System.String" />
+		<cms:binding name="TypeTitle" type="System.String" />
+		<cms:binding name="DataFieldDescriptors" type="System.Object" />
+		<cms:binding name="HasCaching" type="System.Boolean" />
+		<cms:binding name="HasPublishing" type="System.Boolean" />
+		<cms:binding name="HasSorting" type="System.Boolean" />
+		<cms:binding name="KeyFieldName" type="System.String" optional="true" />
+		<cms:binding name="LabelFieldName" type="System.String" optional="true" />
+		<cms:binding name="InternalUrlPrefix" type="System.String" optional="true" />
+	</cms:bindings>
+	<cms:layout iconhandle="generated-type-edit">
+		<cms:layout.label>
+			<cms:read source="TypeName"/>
+		</cms:layout.label>
+		<TabPanels>
+			<PlaceHolder Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.SettingsTab}">
 
-                <FieldGroup Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTitleGroup}">
-                    <TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTitle}" Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HelpTitle}">
-                        <cms:bind source="TypeTitle" />
-                    </TextBox>
-                </FieldGroup>
+				<FieldGroup Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTitleGroup}">
+					<TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTitle}" Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HelpTitle}">
+						<cms:bind source="TypeTitle" />
+					</TextBox>
+				</FieldGroup>
 
 
-                <FieldGroup Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelProgrammaticNamingAndServices}">
-                    <TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTypeName}"
-                         Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HelpTypeName}" Type="ProgrammingIdentifier">
-                        <cms:bind source="TypeName" />
-                    </TextBox>
-                    <TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTypeNamespace}" Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HelpTypeNamespace}" Type="ProgrammingNamespace">
-                        <cms:bind source="TypeNamespace" />
-                    </TextBox>
+				<FieldGroup Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelProgrammaticNamingAndServices}">
+					<TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTypeName}"
+							 Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HelpTypeName}" Type="ProgrammingIdentifier">
+						<cms:bind source="TypeName" />
+					</TextBox>
+					<TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelTypeNamespace}" Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HelpTypeNamespace}" Type="ProgrammingNamespace">
+						<cms:bind source="TypeNamespace" />
+					</TextBox>
 
-                  <TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.InternalUrlPrefixLabel}" Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.InternalUrlPrefixHelp}" Type="programmingidentifier">
-                    <cms:bind source="InternalUrlPrefix" />
-                  </TextBox>
+					<TextBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.InternalUrlPrefixLabel}" Help="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.InternalUrlPrefixHelp}" Type="programmingidentifier">
+						<cms:bind source="InternalUrlPrefix" />
+					</TextBox>
 
-                  <PlaceHolder Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.ServicesLabel}">
-                        <CheckBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasCaching}" ItemLabel="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasCaching}">
-                            <CheckBox.Checked>
-                                <cms:bind source="HasCaching" />
-                            </CheckBox.Checked>
-                        </CheckBox>
-                        <CheckBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasPublishing}" ItemLabel="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasPublishing}">
-                            <CheckBox.Checked>
-                                <cms:bind source="HasPublishing" />
-                            </CheckBox.Checked>
-                        </CheckBox>
-                    </PlaceHolder>
-                </FieldGroup>
-            </PlaceHolder>
-            <internal:TypeFieldDesigner Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelFields}" KeyFieldReadOnly="true">
-                <internal:TypeFieldDesigner.Fields>
-                    <cms:bind source="DataFieldDescriptors" />
-                </internal:TypeFieldDesigner.Fields>
-              <internal:TypeFieldDesigner.KeyFieldName>
-                <cms:bind source="KeyFieldName" />
-              </internal:TypeFieldDesigner.KeyFieldName>
-                <internal:TypeFieldDesigner.LabelFieldName>
-                    <cms:bind source="LabelFieldName" />
-                </internal:TypeFieldDesigner.LabelFieldName>
-            </internal:TypeFieldDesigner>
+					<PlaceHolder Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.ServicesLabel}">
+						<CheckBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasCaching}" ItemLabel="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasCaching}">
+							<CheckBox.Checked>
+								<cms:bind source="HasCaching" />
+							</CheckBox.Checked>
+						</CheckBox>
+						<CheckBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasPublishing}" ItemLabel="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasPublishing}">
+							<CheckBox.Checked>
+								<cms:bind source="HasPublishing" />
+							</CheckBox.Checked>
+						</CheckBox>
+						<CheckBox Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasSorting}" ItemLabel="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.HasSorting}">
+							<CheckBox.Checked>
+								<cms:bind source="HasSorting" />
+							</CheckBox.Checked>
+						</CheckBox>
+					</PlaceHolder>
+				</FieldGroup>
+			</PlaceHolder>
+			<internal:TypeFieldDesigner Label="${Composite.Plugins.GeneratedDataTypesElementProvider, EditorCommon.LabelFields}" KeyFieldReadOnly="true">
+				<internal:TypeFieldDesigner.Fields>
+					<cms:bind source="DataFieldDescriptors" />
+				</internal:TypeFieldDesigner.Fields>
+				<internal:TypeFieldDesigner.KeyFieldName>
+					<cms:bind source="KeyFieldName" />
+				</internal:TypeFieldDesigner.KeyFieldName>
+				<internal:TypeFieldDesigner.LabelFieldName>
+					<cms:bind source="LabelFieldName" />
+				</internal:TypeFieldDesigner.LabelFieldName>
+			</internal:TypeFieldDesigner>
 
-        </TabPanels>
-    </cms:layout>
+		</TabPanels>
+	</cms:layout>
 </cms:formdefinition>

--- a/Website/Composite/localization/Composite.Plugins.GeneratedDataTypesElementProvider.en-us.xml
+++ b/Website/Composite/localization/Composite.Plugins.GeneratedDataTypesElementProvider.en-us.xml
@@ -1,135 +1,139 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <strings>
-  <string key="GlobalDataFolderLabel" value="Global Datatypes" />
-  <string key="GlobalDataFolderToolTip" value="Global datatypes" />
-  <string key="GlobalDataFolderLabel_OnlyGlobalData" value="Website Items" />
-  <string key="GlobalDataFolderToolTip_OnlyGlobalData" value="Website Items (Data)" />
-  <string key="PageDataFolderDataFolderLabel" value="Page Datafolders" />
-  <string key="PageDataFolderDataFolderToolTip" value="Page datafolders" />
-  <string key="PageMetaDataFolderLabel" value="Page Metatypes" />
-  <string key="PageMetaDataFolderToolTip" value="Page metatypes" />
-  <string key="Add" value="Add Datatype" />
-  <string key="AddToolTip" value="Add new global datatype" />
-  <string key="ViewUnpublishedItems" value="List Unpublished Data" />
-  <string key="ViewUnpublishedItemsToolTip" value="Get an overview of data that haven't been published yet" />
-  <string key="ViewUnpublishedItems-document-title" value="Unpublished data" />
-  <string key="ViewUnpublishedItems-document-description" value="The list below display data items which are currently being edited or are ready to be approved / published." />
-  <string key="ViewUnpublishedItems-document-empty-label" value="No unpublished data." />
-  <string key="AddDataFolder" value="Add Datafolder" />
-  <string key="AddDataFolderToolTip" value="Add new datafolder" />
-  <string key="AddMetaDataLabel" value="Add Metatype" />
-  <string key="AddMetaDataToolTip" value="Add metatype" />
-  <string key="Edit" value="Edit Datatype" />
-  <string key="EditToolTip" value="Edit selected datatype" />
-  <string key="EditDataFolderTypeLabel" value="Edit" />
-  <string key="EditDataFolderTypeToolTip" value="Edit selected datafolder" />
-  <string key="EditMetaDataTypeLabel" value="Edit" />
-  <string key="EditMetaDataTypeToolTip" value="Edit selected metadata" />
-  <string key="Delete" value="Delete Datatype" />
-  <string key="DeleteToolTip" value="Delete selected datatype" />
-  <string key="DeleteDataFolderTypeLabel" value="Delete" />
-  <string key="DeleteDataFolderTypeToolTip" value="Delete selected datafolder" />
-  <string key="DeleteMetaDataTypeLabel" value="Delete" />
-  <string key="DeleteMetaDataTypeToolTip" value="Delete selected metadata" />
-  <string key="EditFormMarkup" value="Edit Form Markup" />
-  <string key="EditFormMarkupToolTip" value="Modify the layout of the data form using markup" />
-  <string key="EnableLocalization" value="Enable Localization" />
-  <string key="EnableLocalizationToolTip" value="Enable localization" />
-  <string key="DisableLocalization" value="Disable Localization" />
-  <string key="DisableLocalizationToolTip" value="Disable localization" />
-  <string key="DisabledData" value="Not yet approved or published" />
-  <string key="UndefinedLabelTemplate" value="(undefined [{0}])" />
-  <string key="UndefinedDataLavelTemplate" value="(undefined)" />
-  <string key="ShowInContent" value="Show in Content perspective" />
-  <string key="ShowInContentToolTip" value="Show in Content perspective" />
-  <string key="AddData" value="Add Data" />
-  <string key="AddDataToolTip" value="Add new data" />
-  <string key="EditData" value="Edit Data" />
-  <string key="EditDataToolTip" value="Edit selected data" />
-  <string key="DeleteData" value="Delete Data" />
-  <string key="DeleteDataToolTip" value="Delete selected data" />
-  <string key="LocalizeData" value="Translate Data" />
-  <string key="LocalizeDataToolTip" value="Translate selected data" />
-  <string key="DraftTransition" value="Draft" />
-  <string key="AwaitingApprovalTransition" value="Awaiting Approval" />
-  <string key="PublicationSettings.FieldGroupLabel" value="Publication settings" />
-  <string key="PublicationStatus.Label" value="Status" />
-  <string key="PublicationStatus.Help" value="Send the data to another publication status." />
-  <string key="PublishDate.Label" value="Publish date" />
-  <string key="PublishDate.Help" value="Specify at which date and time you want the data to be published automatically." />
-  <string key="UnpublishDate.Label" value="Unpublish date" />
-  <string key="UnpublishDate.Help" value="Specify at which date and time you want the data to be unpublished automatically." />
-  <string key="AddNewInterfaceTypeStep1.DocumentTitle" value="New Datatype" />
-  <string key="AddNewCompositionTypeWorkflow.DocumentTitle" value="New Page Metatype" />
-  <string key="AddNewAggregationTypeWorkflow.DocumentTitle" value="New Page Datafolder" />
-  <string key="EditorCommon.SettingsTab" value="Settings" />
-  <string key="EditorCommon.LabelTitleGroup" value="Type title" />
-  <string key="EditorCommon.LabelProgrammaticNamingAndServices" value="Programmatic naming and services" />
-  <string key="EditorCommon.LabelProgrammaticNaming" value="Programmatic naming" />
-  <string key="EditorCommon.LabelTypeName" value="Type name" />
-  <string key="EditorCommon.HelpTypeName" value="The technical name of the data type (ex. Product). This is used to identify this type in code and should not be changed once used externally." />
-  <string key="EditorCommon.LabelTypeNamespace" value="Type namespace" />
-  <string key="EditorCommon.HelpTypeNamespace" value="The namespace (module / category name) of the type. This is used to identify this type in code and should not be changed once used externally." />
-  <string key="EditorCommon.LabelTitle" value="Title" />
-  <string key="EditorCommon.HelpTitle" value="Use this entry to specify a user friendly name. This name is used in most UI." />
-  <string key="EditorCommon.LabelFields" value="Fields" />
-  <string key="EditorCommon.KeyFieldTypeLabel" value="Key field type"/>
-  <string key="EditorCommon.KeyFieldTypeHelp" value="The type of the primary key. Use the default 'Guid' type for optimal performance and 'RandomString' for shorter data urls."/>
-  <string key="EditorCommon.KeyFieldType.Guid" value="Guid"/>
-  <string key="EditorCommon.KeyFieldType.RandomString4" value="Random String, 4 characters long"/>
-  <string key="EditorCommon.KeyFieldType.RandomString8" value="Random String, 8 characters long"/>
-  <string key="EditorCommon.ServicesLabel" value="Services" />
-  <string key="EditorCommon.InternalUrlPrefixLabel" value="Short URL name" />
-  <string key="EditorCommon.InternalUrlPrefixHelp" value="When specified, allows data items of the current type to be referenced in content. The internal links will have format '~/{ShortURLName}({id})', f.e. '~/product(aIkH34F)" />
-  <string key="EditorCommon.HasCaching" value="Has caching" />
-  <string key="EditorCommon.HasPublishing" value="Has publishing" />
-  <string key="EditorCommon.HasLocalization" value="Is localizable data" />
-  <string key="DeleteGeneratedDataStep1.LabelFieldGroup" value="Delete Data?" />
-  <string key="DeleteGeneratedDataStep1.Text" value="Delete data?" />
-  <string key="DeleteDataConfirmationText" value="There is some referenced data that will also be deleted, do you want to continue?" />
-  <string key="DeleteGeneratedInterfaceStep1.LabelFieldGroup" value="Delete Datatype" />
-  <string key="DeleteGeneratedInterfaceStep1.Text" value="Delete the datatype" />
-  <string key="CascadeDeleteErrorTitle" value="Cascade delete error" />
-  <string key="CascadeDeleteErrorMessage" value="The type is referenced by another type that does not allow cascade deletes. This operation is halted" />
-  <string key="DeleteAggregationTypeWorkflow.LabelFieldGroup" value="Delete Datatype" />
-  <string key="DeleteAggregationTypeWorkflow.Text" value="Delete the datatype" />
-  <string key="DeleteAggregationTypeWorkflow.ErrorTitle" value="Error" />
-  <string key="DeleteAggregationTypeWorkflow.IsUsedByPageType" value="Cannot delete type '{0}' since it is used by a page type." />  
-  <string key="DeleteCompositionTypeWorkflow.LabelFieldGroup" value="Delete Datatype" />
-  <string key="DeleteCompositionTypeWorkflow.Text" value="Delete the datatype" />
-  <string key="DeleteCompositionTypeWorkflow.ErrorTitle" value="Error" />
-  <string key="DeleteCompositionTypeWorkflow.TypeIsReferenced" value="Cannot delete type '{0}' since there're types that referenced to it." />
-  <string key="DeleteCompositionTypeWorkflow.IsUsedByPageType" value="Cannot delete type '{0}' since it is used by a page type." />  
-  <string key="ToXmlLabel" value="To Xml" />
-  <string key="ToXmlToolTip" value="To Xml" />
-  <string key="EnableTypeLocalizationWorkflow.Dialog.Label" value="Enable Localization" />
-  <string key="EnableTypeLocalizationWorkflow.Step1.FieldGroup.Label" value="Enable localization" />
-  <string key="EnableTypeLocalizationWorkflow.Step1.CultureSelector.Label" value="Move existing data to ..." />
-  <string key="EnableTypeLocalizationWorkflow.Step1.CultureSelector.Help" value="When you enable 'localization' on a data type, all data must belong to a language. Select the language existing data should now be moved to." />
-  <string key="EnableTypeLocalizationWorkflow.Step2.Title" value="Confirmation" />
-  <string key="EnableTypeLocalizationWorkflow.Step2.Description" value="Data type will be localized and data copied to selected locale. Click Finish to continue." />
-  <string key="EnableTypeLocalizationWorkflow.Step3.Title" value="Warning" />
-  <string key="EnableTypeLocalizationWorkflow.Step3.Description" value="There's some datatypes which have references to the type. While localizing the data will be copied to all languages in order to prevent appearing of broken references." />
-  <string key="EnableTypeLocalizationWorkflow.Abort.Title" value="Missing active locales" />
-  <string key="EnableTypeLocalizationWorkflow.Abort.Description" value="There are no added active locales. Add at least one before localization this datatype." />
-  <string key="DisableTypeLocalizationWorkflow.Dialog.Label" value="Disable Localization" />
-  <string key="DisableTypeLocalizationWorkflow.Step1.FieldGroup.Label" value="Disable localization" />
-  <string key="DisableTypeLocalizationWorkflow.Step1.CultureSelector.Label" value="Keep data from ..." />
-  <string key="DisableTypeLocalizationWorkflow.Step1.CultureSelector.Help" value="When localization is disabled on a datatype only one translation can be kept. Data from other languages will be lost." />
-  <string key="DisableTypeLocalizationWorkflow.Step2.Title" value="Confirmation" />
-  <string key="DisableTypeLocalizationWorkflow.Step2.Description" value="All data from other locales than the one selected will be lost. Click Finish to continue." />
-  <string key="LocalizeDataWorkflow.ShowError.LayoutLabel" value="Failed to translate data" />
-  <string key="LocalizeDataWorkflow.ShowError.InfoTableCaption" value="Translation errors" />
-  <string key="LocalizeDataWorkflow.ShowError.AlreadyTranslated" value="This data has already been translated. The translated version belongs to a different group." />
-  <string key="LocalizeDataWorkflow.ShowError.Description" value="The following fields has a reference to a data type. You should translate these data items before you can translate this data item" />
-  <string key="LocalizeDataWorkflow.ShowError.FieldErrorFormat" value="The field '{0}' is referencing data of type '{1}' with the label '{2}'" />
-  <string key="AddNewInterfaceTypeStep1.ErrorTitle" value="Error" />
-  <string key="EditInterfaceTypeStep1.ErrorTitle" value="Error" />
-  <string key="AddNewCompositionTypeWorkflow.ErrorTitle" value="Error" />
-  <string key="EditCompositionTypeWorkflow.ErrorTitle" value="Error" />
-  <string key="DataTypeDescriptorToXmlLabel" value="XML Result" />
+	<string key="GlobalDataFolderLabel" value="Global Datatypes" />
+	<string key="GlobalDataFolderToolTip" value="Global datatypes" />
+	<string key="GlobalDataFolderLabel_OnlyGlobalData" value="Website Items" />
+	<string key="GlobalDataFolderToolTip_OnlyGlobalData" value="Website Items (Data)" />
+	<string key="PageDataFolderDataFolderLabel" value="Page Datafolders" />
+	<string key="PageDataFolderDataFolderToolTip" value="Page datafolders" />
+	<string key="PageMetaDataFolderLabel" value="Page Metatypes" />
+	<string key="PageMetaDataFolderToolTip" value="Page metatypes" />
+	<string key="Add" value="Add Datatype" />
+	<string key="AddToolTip" value="Add new global datatype" />
+	<string key="ViewUnpublishedItems" value="List Unpublished Data" />
+	<string key="ViewUnpublishedItemsToolTip" value="Get an overview of data that haven't been published yet" />
+	<string key="ViewUnpublishedItems-document-title" value="Unpublished data" />
+	<string key="ViewUnpublishedItems-document-description" value="The list below display data items which are currently being edited or are ready to be approved / published." />
+	<string key="ViewUnpublishedItems-document-empty-label" value="No unpublished data." />
+	<string key="AddDataFolder" value="Add Datafolder" />
+	<string key="AddDataFolderToolTip" value="Add new datafolder" />
+	<string key="AddMetaDataLabel" value="Add Metatype" />
+	<string key="AddMetaDataToolTip" value="Add metatype" />
+	<string key="Edit" value="Edit Datatype" />
+	<string key="EditToolTip" value="Edit selected datatype" />
+	<string key="EditDataFolderTypeLabel" value="Edit" />
+	<string key="EditDataFolderTypeToolTip" value="Edit selected datafolder" />
+	<string key="EditMetaDataTypeLabel" value="Edit" />
+	<string key="EditMetaDataTypeToolTip" value="Edit selected metadata" />
+	<string key="Delete" value="Delete Datatype" />
+	<string key="DeleteToolTip" value="Delete selected datatype" />
+	<string key="DeleteDataFolderTypeLabel" value="Delete" />
+	<string key="DeleteDataFolderTypeToolTip" value="Delete selected datafolder" />
+	<string key="DeleteMetaDataTypeLabel" value="Delete" />
+	<string key="DeleteMetaDataTypeToolTip" value="Delete selected metadata" />
+	<string key="EditFormMarkup" value="Edit Form Markup" />
+	<string key="EditFormMarkupToolTip" value="Modify the layout of the data form using markup" />
+	<string key="EnableLocalization" value="Enable Localization" />
+	<string key="EnableLocalizationToolTip" value="Enable localization" />
+	<string key="DisableLocalization" value="Disable Localization" />
+	<string key="DisableLocalizationToolTip" value="Disable localization" />
+	<string key="DisabledData" value="Not yet approved or published" />
+	<string key="UndefinedLabelTemplate" value="(undefined [{0}])" />
+	<string key="UndefinedDataLavelTemplate" value="(undefined)" />
+	<string key="ShowInContent" value="Show in Content perspective" />
+	<string key="ShowInContentToolTip" value="Show in Content perspective" />
+	<string key="AddData" value="Add Data" />
+	<string key="AddDataToolTip" value="Add new data" />
+	<string key="EditData" value="Edit Data" />
+	<string key="EditDataToolTip" value="Edit selected data" />
+	<string key="DeleteData" value="Delete Data" />
+	<string key="DeleteDataToolTip" value="Delete selected data" />
+	<string key="LocalizeData" value="Translate Data" />
+	<string key="LocalizeDataToolTip" value="Translate selected data" />
+	<string key="DraftTransition" value="Draft" />
+	<string key="AwaitingApprovalTransition" value="Awaiting Approval" />
+	<string key="PublicationSettings.FieldGroupLabel" value="Publication settings" />
+	<string key="PublicationStatus.Label" value="Status" />
+	<string key="PublicationStatus.Help" value="Send the data to another publication status." />
+	<string key="PublishDate.Label" value="Publish date" />
+	<string key="PublishDate.Help" value="Specify at which date and time you want the data to be published automatically." />
+	<string key="UnpublishDate.Label" value="Unpublish date" />
+	<string key="UnpublishDate.Help" value="Specify at which date and time you want the data to be unpublished automatically." />
+	<string key="LocalOrdering.FieldGroupLabel" value="Sorting settings" />
+	<string key="LocalOrdering.Label" value="Local ordering" />
+	<string key="LocalOrdering.Help" value="Specify the ordering of the element related to other data items on the same level. Lowest is first." />
+	<string key="AddNewInterfaceTypeStep1.DocumentTitle" value="New Datatype" />
+	<string key="AddNewCompositionTypeWorkflow.DocumentTitle" value="New Page Metatype" />
+	<string key="AddNewAggregationTypeWorkflow.DocumentTitle" value="New Page Datafolder" />
+	<string key="EditorCommon.SettingsTab" value="Settings" />
+	<string key="EditorCommon.LabelTitleGroup" value="Type title" />
+	<string key="EditorCommon.LabelProgrammaticNamingAndServices" value="Programmatic naming and services" />
+	<string key="EditorCommon.LabelProgrammaticNaming" value="Programmatic naming" />
+	<string key="EditorCommon.LabelTypeName" value="Type name" />
+	<string key="EditorCommon.HelpTypeName" value="The technical name of the data type (ex. Product). This is used to identify this type in code and should not be changed once used externally." />
+	<string key="EditorCommon.LabelTypeNamespace" value="Type namespace" />
+	<string key="EditorCommon.HelpTypeNamespace" value="The namespace (module / category name) of the type. This is used to identify this type in code and should not be changed once used externally." />
+	<string key="EditorCommon.LabelTitle" value="Title" />
+	<string key="EditorCommon.HelpTitle" value="Use this entry to specify a user friendly name. This name is used in most UI." />
+	<string key="EditorCommon.LabelFields" value="Fields" />
+	<string key="EditorCommon.KeyFieldTypeLabel" value="Key field type"/>
+	<string key="EditorCommon.KeyFieldTypeHelp" value="The type of the primary key. Use the default 'Guid' type for optimal performance and 'RandomString' for shorter data urls."/>
+	<string key="EditorCommon.KeyFieldType.Guid" value="Guid"/>
+	<string key="EditorCommon.KeyFieldType.RandomString4" value="Random String, 4 characters long"/>
+	<string key="EditorCommon.KeyFieldType.RandomString8" value="Random String, 8 characters long"/>
+	<string key="EditorCommon.ServicesLabel" value="Services" />
+	<string key="EditorCommon.InternalUrlPrefixLabel" value="Short URL name" />
+	<string key="EditorCommon.InternalUrlPrefixHelp" value="When specified, allows data items of the current type to be referenced in content. The internal links will have format '~/{ShortURLName}({id})', f.e. '~/product(aIkH34F)" />
+	<string key="EditorCommon.HasCaching" value="Has caching" />
+	<string key="EditorCommon.HasPublishing" value="Has publishing" />
+	<string key="EditorCommon.HasLocalization" value="Is localizable data" />
+	<string key="EditorCommon.HasSorting" value="Has sorting" />
+	<string key="DeleteGeneratedDataStep1.LabelFieldGroup" value="Delete Data?" />
+	<string key="DeleteGeneratedDataStep1.Text" value="Delete data?" />
+	<string key="DeleteDataConfirmationText" value="There is some referenced data that will also be deleted, do you want to continue?" />
+	<string key="DeleteGeneratedInterfaceStep1.LabelFieldGroup" value="Delete Datatype" />
+	<string key="DeleteGeneratedInterfaceStep1.Text" value="Delete the datatype" />
+	<string key="CascadeDeleteErrorTitle" value="Cascade delete error" />
+	<string key="CascadeDeleteErrorMessage" value="The type is referenced by another type that does not allow cascade deletes. This operation is halted" />
+	<string key="DeleteAggregationTypeWorkflow.LabelFieldGroup" value="Delete Datatype" />
+	<string key="DeleteAggregationTypeWorkflow.Text" value="Delete the datatype" />
+	<string key="DeleteAggregationTypeWorkflow.ErrorTitle" value="Error" />
+	<string key="DeleteAggregationTypeWorkflow.IsUsedByPageType" value="Cannot delete type '{0}' since it is used by a page type." />
+	<string key="DeleteCompositionTypeWorkflow.LabelFieldGroup" value="Delete Datatype" />
+	<string key="DeleteCompositionTypeWorkflow.Text" value="Delete the datatype" />
+	<string key="DeleteCompositionTypeWorkflow.ErrorTitle" value="Error" />
+	<string key="DeleteCompositionTypeWorkflow.TypeIsReferenced" value="Cannot delete type '{0}' since there're types that referenced to it." />
+	<string key="DeleteCompositionTypeWorkflow.IsUsedByPageType" value="Cannot delete type '{0}' since it is used by a page type." />
+	<string key="ToXmlLabel" value="To Xml" />
+	<string key="ToXmlToolTip" value="To Xml" />
+	<string key="EnableTypeLocalizationWorkflow.Dialog.Label" value="Enable Localization" />
+	<string key="EnableTypeLocalizationWorkflow.Step1.FieldGroup.Label" value="Enable localization" />
+	<string key="EnableTypeLocalizationWorkflow.Step1.CultureSelector.Label" value="Move existing data to ..." />
+	<string key="EnableTypeLocalizationWorkflow.Step1.CultureSelector.Help" value="When you enable 'localization' on a data type, all data must belong to a language. Select the language existing data should now be moved to." />
+	<string key="EnableTypeLocalizationWorkflow.Step2.Title" value="Confirmation" />
+	<string key="EnableTypeLocalizationWorkflow.Step2.Description" value="Data type will be localized and data copied to selected locale. Click Finish to continue." />
+	<string key="EnableTypeLocalizationWorkflow.Step3.Title" value="Warning" />
+	<string key="EnableTypeLocalizationWorkflow.Step3.Description" value="There's some datatypes which have references to the type. While localizing the data will be copied to all languages in order to prevent appearing of broken references." />
+	<string key="EnableTypeLocalizationWorkflow.Abort.Title" value="Missing active locales" />
+	<string key="EnableTypeLocalizationWorkflow.Abort.Description" value="There are no added active locales. Add at least one before localization this datatype." />
+	<string key="DisableTypeLocalizationWorkflow.Dialog.Label" value="Disable Localization" />
+	<string key="DisableTypeLocalizationWorkflow.Step1.FieldGroup.Label" value="Disable localization" />
+	<string key="DisableTypeLocalizationWorkflow.Step1.CultureSelector.Label" value="Keep data from ..." />
+	<string key="DisableTypeLocalizationWorkflow.Step1.CultureSelector.Help" value="When localization is disabled on a datatype only one translation can be kept. Data from other languages will be lost." />
+	<string key="DisableTypeLocalizationWorkflow.Step2.Title" value="Confirmation" />
+	<string key="DisableTypeLocalizationWorkflow.Step2.Description" value="All data from other locales than the one selected will be lost. Click Finish to continue." />
+	<string key="LocalizeDataWorkflow.ShowError.LayoutLabel" value="Failed to translate data" />
+	<string key="LocalizeDataWorkflow.ShowError.InfoTableCaption" value="Translation errors" />
+	<string key="LocalizeDataWorkflow.ShowError.AlreadyTranslated" value="This data has already been translated. The translated version belongs to a different group." />
+	<string key="LocalizeDataWorkflow.ShowError.Description" value="The following fields has a reference to a data type. You should translate these data items before you can translate this data item" />
+	<string key="LocalizeDataWorkflow.ShowError.FieldErrorFormat" value="The field '{0}' is referencing data of type '{1}' with the label '{2}'" />
+	<string key="AddNewInterfaceTypeStep1.ErrorTitle" value="Error" />
+	<string key="EditInterfaceTypeStep1.ErrorTitle" value="Error" />
+	<string key="AddNewCompositionTypeWorkflow.ErrorTitle" value="Error" />
+	<string key="EditCompositionTypeWorkflow.ErrorTitle" value="Error" />
+	<string key="DataTypeDescriptorToXmlLabel" value="XML Result" />
 
-  <string key="FormMarkupInfo.Dialog.Label" value="This type has custom form markup" />
-  <string key="FormMarkupInfo.Message" value="Your field changes will not affect the form for editing data.
+	<string key="FormMarkupInfo.Dialog.Label" value="This type has custom form markup" />
+	<string key="FormMarkupInfo.Message" value="Your field changes will not affect the form for editing data.
 Do '{0}' to change the form or delete the file '{1}'." />
 </strings>


### PR DESCRIPTION
This pull request lays the foundation for more intuitive sorting of items within the C1 Console, as discussed in this feature request http://compositec1.codeplex.com/workitem/770.

The code is from the C1Contrib.Sorting package, without the UI from drag-n-drop sorting (yet) since i feel this needs some discussion for how it should math the look and feel of the new console.

It refactors the LocalOrdering property from IPageStructure into a new interface which can then be applied to all IData elements. A new "Is sortable" checbox is also exposed when creating and editing dynamic datatypes through the Console and a new textbox for entering the sortorder is added to the Default Form Markup.