### PR TITLE
Remove dependency on SharpZipLib

### DIFF
--- a/Composite.Workflows/Composite.Workflows.csproj
+++ b/Composite.Workflows/Composite.Workflows.csproj
@@ -61,10 +61,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\bin\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>

--- a/Composite.Workflows/Plugins/Elements/ElementProviders/MediaFileProviderElementProvider/AddMediaZipFileWorkflow.cs
+++ b/Composite.Workflows/Plugins/Elements/ElementProviders/MediaFileProviderElementProvider/AddMediaZipFileWorkflow.cs
@@ -8,7 +8,6 @@ using Composite.C1Console.Workflow;
 using Composite.C1Console.Workflow.Activities;
 using Composite.Data;
 using Composite.Data.Types;
-using ICSharpCode.SharpZipLib.Zip;
 
 
 namespace Composite.Plugins.Elements.ElementProviders.MediaFileProviderElementProvider
@@ -82,7 +81,7 @@ namespace Composite.Plugins.Elements.ElementProviders.MediaFileProviderElementPr
                         ZipMediaFileExtractor.AddZip(providerName, parentFolderPath, readStream, recreateFolders, overwrite);
                         _zipHasBeenUploaded = true;
                     }
-                    catch (ZipException)
+                    catch (Exception)
                     {
                     }
                 }
@@ -129,9 +128,9 @@ namespace Composite.Plugins.Elements.ElementProviders.MediaFileProviderElementPr
 
         private void ShowUploadError(string message)
         {
-            //TODO: Cannot show an error bubble on file selector since the control doesn't support it. Should be fixed on client js 
+            //TODO: Cannot show an error bubble on file selector since the control doesn't support it. Should be fixed on client js
             //this.ShowFieldMessage("UploadedFile", "${Composite.Management, Website.Forms.Administrative.AddZipMediaFile.MissingUploadedFile.Message}");
-            this.ShowMessage(DialogType.Error, 
+            this.ShowMessage(DialogType.Error,
                 "${Composite.Management, Website.Forms.Administrative.AddZipMediaFile.Error.Title}",
                 message);
         }

--- a/Composite.Workflows/packages.config
+++ b/Composite.Workflows/packages.config
@@ -3,5 +3,4 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
 </packages>

--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -66,10 +66,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Framework.DependencyInjection, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Framework.DependencyInjection.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.dll</HintPath>
@@ -104,6 +100,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.EnterpriseServices" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Management" />
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization">

--- a/Composite/Core/PackageSystem/Foundation/XmlHelper.cs
+++ b/Composite/Core/PackageSystem/Foundation/XmlHelper.cs
@@ -30,7 +30,8 @@ namespace Composite.Core.PackageSystem.Foundation
 
             try
             {
-                using (C1StreamReader streamReader = new C1StreamReader(zipFileSystem.GetFileStream(filename)))
+                using (var stream = zipFileSystem.GetFileStream(filename))
+                using (var streamReader = new C1StreamReader(stream))
                 {
                     string fileContent = streamReader.ReadToEnd();
                     installElement = XElement.Parse(fileContent);

--- a/Composite/Core/PackageSystem/PackageFragmentInstallers/DataPackageFragmentInstaller.cs
+++ b/Composite/Core/PackageSystem/PackageFragmentInstallers/DataPackageFragmentInstaller.cs
@@ -305,7 +305,8 @@ namespace Composite.Core.PackageSystem.PackageFragmentInstallers
                     XDocument doc;
                     try
                     {
-                        using (var reader = new C1StreamReader(this.InstallerContext.ZipFileSystem.GetFileStream(dataFilenameAttribute.Value)))
+                        using (var stream = this.InstallerContext.ZipFileSystem.GetFileStream(dataFilenameAttribute.Value))
+                        using (var reader = new C1StreamReader(stream))
                         {
                             doc = XDocument.Load(reader);
                         }

--- a/Composite/packages.config
+++ b/Composite/packages.config
@@ -5,5 +5,4 @@
   <package id="Microsoft.Framework.DependencyInjection" version="1.0.0-beta8" targetFramework="net45" />
   <package id="Microsoft.Framework.DependencyInjection.Abstractions" version="1.0.0-beta8" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
 </packages>

--- a/Website/packages.config
+++ b/Website/packages.config
@@ -11,5 +11,4 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="0.2.0-pre" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="PhantomJS" version="1.9.7" targetFramework="net45" />
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This pull request removes dependency on SharpZipLib and replaces zip-handling with System.IO.Compression. Fixes https://github.com/Orckestra/C1-CMS/issues/29