### PR TITLE
Browser path separator too light

### DIFF
--- a/Website/Composite/content/views/browser/browser.css
+++ b/Website/Composite/content/views/browser/browser.css
@@ -107,7 +107,7 @@ ui|path {
 			content: "/";
 			display: block;
 			position: absolute;
-			color: #ddd;
+			color: #999;
 			left: 0;
 			top: 6px;
 		}

--- a/Website/Composite/localization/Composite.Plugins.WebsiteFileElementProvider.en-us.xml
+++ b/Website/Composite/localization/Composite.Plugins.WebsiteFileElementProvider.en-us.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <strings>
-	<string key="WebsiteFilesRootElement.Label" value="/" />
-	<string key="LayoutResourcesRootElement.Label" value="/" /> <!-- Layout Resources -->
+	<string key="WebsiteFilesRootElement.Label" value="Root" />
+	<string key="LayoutResourcesRootElement.Label" value="Root" /> <!-- Layout Resources -->
 	<string key="LayoutResourcesKeyNameLabel" value="Layout" />
 	
 	<string key="DeleteFile.LabelFieldGroup" value="Delete File?" />

--- a/Website/gruntfile.js
+++ b/Website/gruntfile.js
@@ -1,4 +1,4 @@
-/// <vs BeforeBuild='less' AfterBuild='less, cssmin' />
+/// <vs BeforeBuild='less' AfterBuild='less, postcss' />
 module.exports = function (grunt) {
 
 	'use strict';
@@ -19,12 +19,10 @@ module.exports = function (grunt) {
 	//************************************************************************************************************************************************
 	// COPYING FROM BOWER COMPONENTS
 	//************************************************************************************************************************************************
-
 	grunt.loadNpmTasks('grunt-contrib-copy');
 	grunt.config("copy", {
 		codemirror: {
 			files: [
-				{ expand: true, cwd: 'bower_components/codemirror/addon/dropmedia', src: ['*.*'], dest: 'Composite/lib/codemirror/addon/dropmedia' },
 				{ expand: true, cwd: 'bower_components/codemirror/addon/mode', src: ['*.*'], dest: 'Composite/lib/codemirror/addon/mode' },
 				{ expand: true, cwd: 'bower_components/codemirror/addon/selection', src: ['*.*'], dest: 'Composite/lib/codemirror/addon/selection' },
 				{ expand: true, cwd: 'bower_components/codemirror/lib', src: ['*.*'], dest: 'Composite/lib/codemirror/lib' },
@@ -33,7 +31,6 @@ module.exports = function (grunt) {
 				{ expand: true, cwd: 'bower_components/codemirror/mode/htmlembedded', src: ['*.*'], dest: 'Composite/lib/codemirror/mode/htmlembedded' },
 				{ expand: true, cwd: 'bower_components/codemirror/mode/htmlmixed', src: ['*.*'], dest: 'Composite/lib/codemirror/mode/htmlmixed' },
 				{ expand: true, cwd: 'bower_components/codemirror/mode/javascript', src: ['*.*'], dest: 'Composite/lib/codemirror/mode/javascript' },
-				{ expand: true, cwd: 'bower_components/codemirror/mode/razor', src: ['*.*'], dest: 'Composite/lib/codemirror/mode/razor' },
 				{ expand: true, cwd: 'bower_components/codemirror/mode/sass', src: ['*.*'], dest: 'Composite/lib/codemirror/mode/sass' },
 				{ expand: true, cwd: 'bower_components/codemirror/mode/xml', src: ['*.*'], dest: 'Composite/lib/codemirror/mode/xml' }
 			]

--- a/Website/package.json
+++ b/Website/package.json
@@ -6,7 +6,6 @@
 	"devDependencies": {
 		"grunt": "~0.4.5",
 		"grunt-contrib-less": "^1.0.0",
-		"grunt-contrib-cssmin": "~0.12.1",
 		"grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-copy": "0.8.2",


### PR DESCRIPTION
The root path is (logically) represented as "/". But now the browser path displays "///" where the middle slash should be (is) clickable. The word "Root" is just a suggestion.