### PR TITLE
Tab highlight fix #81

### DIFF
--- a/Website/Composite/styles/default/fields/checkbox.less
+++ b/Website/Composite/styles/default/fields/checkbox.less
@@ -27,6 +27,12 @@ ui|checkbox {
 		float: none;
 		margin-left: 18px;
 	}
+	
+	&.focused, &:focus, &:hover {
+		ui|labelbody:before {
+			border: 1px solid @primary-color !important;
+		}
+	}
 }
 
 ui|checkbutton {
@@ -52,9 +58,9 @@ ui|checkbutton {
 		}
 	}
 
-	&.hover {
+	&.hover, &:focus, &:hover {
 		ui|labelbody:before {
-			border-color: @primary-color;
+			border: 1px solid @primary-color !important;
 		}
 	}
 

--- a/Website/Composite/styles/default/fields/fields-base.less
+++ b/Website/Composite/styles/default/fields/fields-base.less
@@ -310,6 +310,12 @@ ui|editortextbox {
 			border-color: @field-error-color;
 		}
 	}
+	
+	&.focused, :focus, :hover {
+		ui|box, ui|labelbox {
+			border: 1px solid @primary-color !important;
+		}
+	}
 }
 
 /* EXOTIC STUFF ................................... */

--- a/Website/Composite/styles/default/fields/fields-base.less
+++ b/Website/Composite/styles/default/fields/fields-base.less
@@ -311,7 +311,7 @@ ui|editortextbox {
 		}
 	}
 	
-	&.focused, :focus, :hover {
+	&.focused, &:focus, &:hover {
 		ui|box, ui|labelbox {
 			border: 1px solid @primary-color !important;
 		}


### PR DESCRIPTION
Tab highlight fix for #81. When tabbing into or hovering over a form field, the grey field border is changed to the C1 brand green. It's subtle, but in-keeping with the rest of the console UI.