### PR TITLE
Mark ISerializerHandler and SerializerHandlerAttribute as public

### DIFF
--- a/Composite/Core/Serialization/ISerializerHandler.cs
+++ b/Composite/Core/Serialization/ISerializerHandler.cs
@@ -1,8 +1,22 @@
 ﻿namespace Composite.Core.Serialization
 {
-	internal interface ISerializerHandler
+    /// <summary>
+    /// Handler to serialize and deserialize data for use in Workflows during ie. postbacks.
+    /// </summary>
+	public interface ISerializerHandler
 	{
+        /// <summary>
+        /// Returns a string representation of an object
+        /// </summary>
+        /// <param name="objectToSerialize"></param>
+        /// <returns></returns>
         string Serialize(object objectToSerialize);
+
+        /// <summary>
+        /// Returns the constructed object deserialized from the passed string
+        /// </summary>
+        /// <param name="serializedObject"></param>
+        /// <returns></returns>
         object Deserialize(string serializedObject);
 	}
 }

--- a/Composite/Core/Serialization/SerializerHandlerAttribute.cs
+++ b/Composite/Core/Serialization/SerializerHandlerAttribute.cs
@@ -1,17 +1,25 @@
 ﻿using System;
 
-
 namespace Composite.Core.Serialization
 {
+    /// <summary>
+    /// Defines which <see cref="ISerializerHandler" /> is used to serialize and deserialize this class
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, Inherited = false)]
-    internal sealed class SerializerHandlerAttribute : Attribute
+    public sealed class SerializerHandlerAttribute : Attribute
     {
+        /// <summary>
+        /// Defines which <see cref="ISerializerHandler" /> is used to serialize and deserialize this class
+        /// </summary>
+        /// <param name="serializerHandlerType"></param>
         public SerializerHandlerAttribute(Type serializerHandlerType)
         {
             this.SerializerHandlerType = serializerHandlerType;
         }
 
-
+        /// <summary>
+        /// The <see cref="ISerializerHandler" /> type which is used to serialize and deserialize the class the attribute is added to
+        /// </summary>
         public Type SerializerHandlerType { get; private set; }
     }
 }


### PR DESCRIPTION
Mark ISerializerHandler and SerializerHandlerAttribute as public to allow implementing Workflows and UI Controls that requires custom serialization of postback data.

During a project where i was to implement a Upload File dialog that supported multiple files i found myself in need to add a new class that could hold my posted data which in turn needed to be serialized using ISerializerHandler. Unfortunately this and related interfaces is marked as internal so this pull request marks the necessary interfaces as public.