### PR TITLE
Fixing issue where editing pages with metadfata fail ...

### DIFF
--- a/Composite/Plugins/Forms/WebChannel/UiContainerFactories/TemplatedUiContainerBase.cs
+++ b/Composite/Plugins/Forms/WebChannel/UiContainerFactories/TemplatedUiContainerBase.cs
@@ -87,25 +87,6 @@ namespace Composite.Plugins.Forms.WebChannel.UiContainerFactories
                 }
             }
 
-            if (RuntimeInformation.IsTestEnvironment) {
-
-                try
-                {
-                    var mappings = new Dictionary<string, string>();
-                    FormFlowUiDefinitionRenderer.ResolveBindingPathToCliendIDMappings(GetContainer(), mappings);
-                    var control = new HtmlGenericControl("ui:resolvercontainer");
-                    control.Attributes.Add("class", "resolvercontainer hide");
-                    foreach (var mapping in mappings)
-                    {
-                        control.Attributes.Add($"data-{mapping.Key}", mapping.Value);
-                    }
-                    GetFormPlaceHolder().Controls.Add(control);
-                }
-                catch {
-                    //Nothing
-                }
-            }
-
             base.OnPreRender(e);
         }
 


### PR DESCRIPTION
… with an XML/XSLT exception on post render steps. Done by removing <ui:resolvercontainer /> from form ui templates - this element was included in the original e2e branch to help resolve input fields in forms, but the attribute generation on the element could generate illegal names (specifically containing :). Also, the strategy for targeting fields have changed, making this code obsolete.