### PR TITLE
Ensuring /test folder is removed in build/package process

### DIFF
--- a/Website/ReleaseCleanupConfiguration.xml
+++ b/Website/ReleaseCleanupConfiguration.xml
@@ -20,6 +20,7 @@
 			<Directory path="\Composite\images\icons\republic" />
 			<Directory path="\Composite\images\originals" />
       <Directory path="\Composite\transformations\temp" />
+      <Directory path="\test" />
     </Directories>
 		<Files>
 			<File path="\App_Data\Composite\clean.bat" />

--- a/Website/test/e2e/README.md
+++ b/Website/test/e2e/README.md
@@ -14,6 +14,8 @@ The next step is installing nightwatch itself. This is done by issuing the comma
 
 Finally, navigate to the root directory of your C1 working copy. This will usually be named `C1-CMS`, but you may have named it otherwise when cloning it. In this directory, you can then start the tests by running `nightwatch` from your command line. This will run the whole test suite, starting with installing the Venus starter site.
 
+Nightwatch expects to find the CMS running on localhost, port 8080. You can either change your Visual Studio or WebMatrix/IIS setup to use this port, or edit the `nightwatch.json` configuration file found in the project root. You can edit the line that says `"launch_url" : "http://localhost:8080"` to reflect the URL used.
+
 Due to certain technical limitations, nightwatch must always be run from the working directory, and cannot be run from any subdirectory.
 
 ## Running tests separately


### PR DESCRIPTION
This ensure that our current build/package flow exclude the /test folder from the release packages. I can see some merit in moving the /test folder to the project root though.